### PR TITLE
fix: broken redux selectors and dispatcher typescript inference

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -44,7 +44,6 @@ const persistConfig = {
   version: 1,
   storage,
   migrate: createMigrate(migrations),
-  transforms: [nestedBlacklist],
   blacklist: [
     "user",
     "preferences",
@@ -53,9 +52,13 @@ const persistConfig = {
     "adminAnalytics",
     api.reducerPath,
   ],
+  transforms: [nestedBlacklist],
 };
 
-const persistedReducer = persistReducer(persistConfig, rootReducer);
+const persistedReducer = persistReducer(
+  persistConfig,
+  rootReducer
+) as typeof rootReducer;
 
 export const store = configureStore({
   reducer: persistedReducer,


### PR DESCRIPTION
## Issue 
The type inference for all state slices, reducers and actions were defaulted to `any` after adding the nestedBlacklist transformer which infers `newState as any`.

## Solution
Infer types in the persistedReducer declaration as `typeof rootReducer` to by pass issue.