### PR TITLE
Refactor/Cleanup excerpts from Cover image/node metadata feature

### DIFF
--- a/src/components/molecules/ComponentCard.tsx
+++ b/src/components/molecules/ComponentCard.tsx
@@ -1,7 +1,6 @@
 import axios from "axios";
 import React, { useEffect, useMemo, useState } from "react";
 import styled, { StyledComponent } from "styled-components";
-import ButtonCopyLink from "@components/atoms/ButtonCopyLink";
 import { FlexColumn, FlexRowSpaceBetween } from "@components/styled";
 
 import AnnotationSwitcher from "@components/atoms/AnnotationSwitcher";
@@ -9,7 +8,6 @@ import {
   ExternalLinkComponent,
   PdfComponentPayload,
   ResearchObjectComponentType,
-  ResearchObjectV1,
   ResearchObjectV1Component,
 } from "@desci-labs/desci-models";
 import { cleanupManifestUrl } from "@components/utils";
@@ -18,8 +16,6 @@ import ReactTooltip from "react-tooltip";
 import { findTarget } from "@components/organisms/ComponentLibrary";
 import ButtonFair from "@components/atoms/ButtonFair";
 import {
-  DRIVE_DATA_PATH,
-  DRIVE_NODE_ROOT_PATH,
   SessionStorageKeys,
 } from "../driveUtils";
 import { useSetter } from "@src/store/accessors";
@@ -28,7 +24,6 @@ import { updatePdfPreferences } from "@src/state/nodes/pdf";
 import { useNodeReader } from "@src/state/nodes/hooks";
 import {
   navigateToDriveByPath,
-  setComponentTypeBeingAssignedTo,
   setFileBeingCited,
   setFileBeingUsed,
 } from "@src/state/drive/driveSlice";
@@ -105,7 +100,7 @@ const iconFor = (
 const ComponentCard = (props: ComponentCardProps) => {
   const dispatch = useSetter();
   const { component } = props;
-  const { mode, componentStack, recentlyAddedComponent, manifest } =
+  const { componentStack, recentlyAddedComponent, manifest } =
     useNodeReader();
   const { nodeTree } = useDrive();
   /***
@@ -199,6 +194,7 @@ const ComponentCard = (props: ComponentCardProps) => {
     : "";
 
   if (component.type === ResearchObjectComponentType.LINK) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     copyLinkUrl = (component as ExternalLinkComponent).payload.url;
   }
 
@@ -350,7 +346,7 @@ const ComponentCard = (props: ComponentCardProps) => {
                     <div
                       style={{
                         display:
-                          component.type == ResearchObjectComponentType.PDF
+                          component.type === ResearchObjectComponentType.PDF
                             ? ""
                             : "none",
                       }}

--- a/src/components/organisms/Drive/ContextMenu/useActionHandler.tsx
+++ b/src/components/organisms/Drive/ContextMenu/useActionHandler.tsx
@@ -4,8 +4,7 @@ import {
   ResearchObjectComponentType,
   ResearchObjectV1Component,
 } from "@desci-labs/desci-models";
-import { useHistoryReader, useNodeReader } from "@src/state/nodes/hooks";
-import { useSetNodeCoverMutation } from "@src/state/api/media";
+import { useNodeReader } from "@src/state/nodes/hooks";
 import {
   saveManifestDraft,
   setComponentStack,
@@ -23,8 +22,6 @@ import { deleteData } from "@src/api";
 import { DRIVE_FULL_EXTERNAL_LINKS_PATH } from "@src/state/drive/utils";
 import { deleteComponent } from "@src/state/nodes/viewer";
 import { useDrive } from "@src/state/drive/hooks";
-import useNodeHistory from "@components/organisms/SidePanel/ManuscriptSidePanel/Tabs/History/useNodeHistory";
-// import { useCallback } from "react";
 
 const IPFS_URL = process.env.REACT_APP_IPFS_RESOLVER_OVERRIDE;
 const PUB_IPFS_URL = process.env.REACT_APP_PUBLIC_IPFS_RESOLVER;
@@ -73,15 +70,6 @@ export default function useActionHandler() {
     mode,
   } = useNodeReader();
   const { deprecated } = useDrive();
-  const [setCover, { isLoading: isSettingCover }] = useSetNodeCoverMutation();
-  const { selectedHistoryId } = useHistoryReader();
-  const { loadingChain, history } = useNodeHistory();
-  const version = loadingChain
-    ? selectedHistoryId
-    : history.length
-    ? `v${history.length}`
-    : 0;
-  
 
   async function preview(file: DriveObject) {
     if (
@@ -109,36 +97,6 @@ export default function useActionHandler() {
       }
     }
   }
-
-  // const setNodeCover = useCallback(
-  //   async (file: DriveObject) => {
-  //     if (isSettingCover) return;
-  //     if (
-  //       file.componentType === ResearchObjectComponentType.PDF &&
-  //       file.type !== FileType.DIR
-  //     ) {
-  //       const component = manifestData?.components.find(
-  //         (c: ResearchObjectV1Component) => c.payload.url === file.cid
-  //       );
-  //       if (component) {
-  //         setCover({
-  //           cid: component.payload.url!,
-  //           uuid: currentObjectId!,
-  //           version,
-  //         });
-  //       }
-  //     } else {
-  //       // show error toast or smth
-  //     }
-  //   },
-  //   [
-  //     currentObjectId,
-  //     isSettingCover,
-  //     manifestData?.components,
-  //     setCover,
-  //     version,
-  //   ]
-  // );
 
   async function remove(file: DriveObject) {
     if (mode !== "editor") return;

--- a/src/components/organisms/ManuscriptReader/hooks/useNodeCover.tsx
+++ b/src/components/organisms/ManuscriptReader/hooks/useNodeCover.tsx
@@ -28,11 +28,10 @@ export default function useNodeCover() {
     (doc) =>
       doc.subtype === ResearchObjectComponentDocumentSubtype.RESEARCH_ARTICLE
   );
-  console.log("pdfs", pdfs, manifest?.components)
   const { isLoading, data, isSuccess } = useNodesMediaCoverQuery(
     { cid: pdf?.payload?.url!, uuid: currentObjectId!, version },
     {
-      skip: !pdf?.payload?.url || !currentObjectId,
+      skip: !currentObjectId,
     }
   );
 
@@ -42,7 +41,6 @@ export default function useNodeCover() {
     ]);
   }, [currentObjectId, version]);
 
-  // console.log("cover", isLoading, data, isSuccess, isError);
   return {
     cover: isSuccess ? data.url : "",
     isLoading,

--- a/src/state/api/media.ts
+++ b/src/state/api/media.ts
@@ -24,33 +24,7 @@ export const nodesMediaApi = api.injectEndpoints({
         } catch (error) {}
       },
     }),
-    setNodeCover: builder.mutation<
-      { url: string; ok: boolean },
-      NodeCoverParams
-    >({
-      query: ({ cid, uuid, version }: NodeCoverParams) => {
-        return {
-          url: `${endpoints.v1.nodes.media.cover}${uuid}${
-          version ? `/${version}` : ""
-        }?cid=${cid}`,
-          method: "POST",
-        };
-      },
-      async onQueryStarted(
-        args: NodeCoverParams,
-        { dispatch, queryFulfilled }
-      ) {
-        try {
-          const {
-            data: { url },
-          } = await queryFulfilled;
-          console.log("cover set", url);
-        } catch (error) {
-          console.log("Error setting node cover", args, error);
-        }
-      },
-    }),
   }),
 });
 
-export const { useNodesMediaCoverQuery, useSetNodeCoverMutation } = nodesMediaApi;
+export const { useNodesMediaCoverQuery } = nodesMediaApi;


### PR DESCRIPTION
 - optionally require cid to trigger getCoverImage, 
 - clean up unused  setNodeCover query 
 - remove dead code