### PR TITLE
Refactor calling logic for node cover

### DIFF
--- a/src/components/organisms/Drive/ContextMenu/useActionHandler.tsx
+++ b/src/components/organisms/Drive/ContextMenu/useActionHandler.tsx
@@ -4,8 +4,7 @@ import {
   ResearchObjectComponentType,
   ResearchObjectV1Component,
 } from "@desci-labs/desci-models";
-import { useHistoryReader, useNodeReader } from "@src/state/nodes/hooks";
-import { useSetNodeCoverMutation } from "@src/state/api/media";
+import {  useNodeReader } from "@src/state/nodes/hooks";
 import {
   saveManifestDraft,
   setComponentStack,
@@ -27,8 +26,6 @@ import { deleteData } from "@src/api";
 import { DRIVE_FULL_EXTERNAL_LINKS_PATH } from "@src/state/drive/utils";
 import { deleteComponent } from "@src/state/nodes/viewer";
 import { useDrive } from "@src/state/drive/hooks";
-import useNodeHistory from "@components/organisms/SidePanel/ManuscriptSidePanel/Tabs/History/useNodeHistory";
-// import { useCallback } from "react";
 
 const IPFS_URL = process.env.REACT_APP_IPFS_RESOLVER_OVERRIDE;
 const PUB_IPFS_URL = process.env.REACT_APP_PUBLIC_IPFS_RESOLVER;
@@ -77,14 +74,6 @@ export default function useActionHandler() {
     mode,
   } = useNodeReader();
   const { deprecated } = useDrive();
-  const [setCover, { isLoading: isSettingCover }] = useSetNodeCoverMutation();
-  const { selectedHistoryId } = useHistoryReader();
-  const { loadingChain, history } = useNodeHistory();
-  const version = loadingChain
-    ? selectedHistoryId
-    : history.length
-    ? `v${history.length}`
-    : 0;
 
   async function preview(file: DriveObject) {
     if (

--- a/src/components/organisms/ManuscriptReader/hooks/useNodeCover.tsx
+++ b/src/components/organisms/ManuscriptReader/hooks/useNodeCover.tsx
@@ -1,48 +1,44 @@
-import {
-  PdfComponent,
-  ResearchObjectComponentDocumentSubtype,
-  ResearchObjectComponentType,
-} from "@desci-labs/desci-models";
 import { useNodesMediaCoverQuery } from "@src/state/api/media";
 import { useHistoryReader, useNodeReader } from "@src/state/nodes/hooks";
 import useNodeHistory from "@components/organisms/SidePanel/ManuscriptSidePanel/Tabs/History/useNodeHistory";
 import { useEffect } from "react";
 import { nodesApi } from "@src/state/api/nodes";
 import { tags } from "@src/state/api/tags";
+import { useLoaderData } from "react-router-dom";
+import { manuscriptLoader } from "@src/components/screens/Nodes";
 
 export default function useNodeCover() {
-  const { manifest, currentObjectId } = useNodeReader();
+  const parsedManuscript = useLoaderData() as Awaited<
+    ReturnType<typeof manuscriptLoader>
+  >;
+  const { currentObjectId } = useNodeReader();
   const { selectedHistoryId } = useHistoryReader();
   const { loadingChain, history } = useNodeHistory();
 
-  const version = loadingChain
-    ? selectedHistoryId
-    : history.length
-    ? `v${history.length}`
-    : 0;
+  const version =
+    "version" in parsedManuscript
+      ? parsedManuscript.version
+      : loadingChain
+      ? ""
+      : history.length
+      ? `v${history.length}`
+      : "0";
 
-  const pdfs = manifest?.components.filter(
-    (c) => c.type === ResearchObjectComponentType.PDF // component.subType should be used when available on model
-  ) as PdfComponent[];
-  const pdf = pdfs?.find(
-    (doc) =>
-      doc.subtype === ResearchObjectComponentDocumentSubtype.RESEARCH_ARTICLE
-  );
-  console.log("pdfs", pdfs, manifest?.components)
   const { isLoading, data, isSuccess } = useNodesMediaCoverQuery(
-    { cid: pdf?.payload?.url!, uuid: currentObjectId!, version },
+    { cid: "", uuid: currentObjectId!, version },
     {
-      skip: !pdf?.payload?.url || !currentObjectId,
+      skip: !currentObjectId,
     }
   );
 
   useEffect(() => {
+    console.log("load --version", version);
+    if (isLoading) return;
     nodesApi.util.invalidateTags([
       { type: tags.mediaCover, id: `${currentObjectId}/${version}` },
     ]);
-  }, [currentObjectId, version]);
+  }, [currentObjectId, isLoading, selectedHistoryId, version]);
 
-  // console.log("cover", isLoading, data, isSuccess, isError);
   return {
     cover: isSuccess ? data.url : "",
     isLoading,

--- a/src/state/api/media.ts
+++ b/src/state/api/media.ts
@@ -14,9 +14,7 @@ export const nodesMediaApi = api.injectEndpoints({
         },
       ],
       query: ({ cid, uuid, version }: NodeCoverParams) =>
-        `${endpoints.v1.nodes.media.cover}${uuid}${
-          version ? `/${version}` : ""
-        }?cid=${cid}`,
+        `${endpoints.v1.nodes.media.cover}${uuid}${`/${version}`}?cid=${cid}`,
       async onQueryStarted(args, { dispatch, queryFulfilled }) {
         try {
           console.log("nodesMediaCover", args);
@@ -24,33 +22,7 @@ export const nodesMediaApi = api.injectEndpoints({
         } catch (error) {}
       },
     }),
-    setNodeCover: builder.mutation<
-      { url: string; ok: boolean },
-      NodeCoverParams
-    >({
-      query: ({ cid, uuid, version }: NodeCoverParams) => {
-        return {
-          url: `${endpoints.v1.nodes.media.cover}${uuid}${
-          version ? `/${version}` : ""
-        }?cid=${cid}`,
-          method: "POST",
-        };
-      },
-      async onQueryStarted(
-        args: NodeCoverParams,
-        { dispatch, queryFulfilled }
-      ) {
-        try {
-          const {
-            data: { url },
-          } = await queryFulfilled;
-          console.log("cover set", url);
-        } catch (error) {
-          console.log("Error setting node cover", args, error);
-        }
-      },
-    }),
   }),
 });
 
-export const { useNodesMediaCoverQuery, useSetNodeCoverMutation } = nodesMediaApi;
+export const { useNodesMediaCoverQuery } = nodesMediaApi;


### PR DESCRIPTION
- remove cid parsing from UI logic
- clean up `useNodeCover` hook
- 