### PR TITLE
Minor Fix/Filter undesired files in frontend

### DIFF
--- a/src/state/drive/utils.ts
+++ b/src/state/drive/utils.ts
@@ -170,12 +170,16 @@ export function hasPublic(tree: DriveObject): boolean {
   });
 }
 
+// Prevent rendering certain files in the tree in the drive view
+const FILTER_LIST = [".nodeKeep", ".DS_Store"];
+
 //Convert IPFS tree to DriveObject tree V2
 export function convertIpfsTreeToDriveObjectTree(
   tree: DriveObject[],
   pathToCompMap: Record<DrivePath, ResearchObjectV1Component>,
   pathToSizeMap: Record<DrivePath, number>
 ) {
+  tree = tree.filter((branch) => !FILTER_LIST.includes(branch.name));
   tree.forEach((branch) => {
     const fileDirBranch = branch as FileDir;
     const neutralPath = neutralizePath(branch.path!);


### PR DESCRIPTION
## Description of the Problem / Feature
With the backend returning raw trees, some undesired files are rendered, i.e. nodeKeep and ds_store.
## Explanation of the solution
Undesired files are filtered on the frontend when morphing the backend returned tree into a DriveObject tree.