### PR TITLE
Move Metadata Keywords UI to Current Tab

### DIFF
--- a/src/components/organisms/SidePanel/ManuscriptSidePanel/Tabs/Components/MetadataKeywords.tsx
+++ b/src/components/organisms/SidePanel/ManuscriptSidePanel/Tabs/Components/MetadataKeywords.tsx
@@ -12,9 +12,9 @@ const ContentWrapper = styled(FlexRowAligned)`
   gap: 8px;
 `;
 
-interface PropertyTagsSectionProps {}
+interface MetadataKeywordsProps {}
 
-const PropertyTagsSection = (props: PropertyTagsSectionProps) => {
+const MetadataKeywords = (props: MetadataKeywordsProps) => {
   const { manifest: manifestData, mode } = useNodeReader();
 
   const isEditing = mode === "editor";
@@ -62,4 +62,4 @@ const PropertyTagsSection = (props: PropertyTagsSectionProps) => {
   );
 };
 
-export default PropertyTagsSection;
+export default MetadataKeywords;

--- a/src/components/organisms/SidePanel/ManuscriptSidePanel/Tabs/CreditTab/index.tsx
+++ b/src/components/organisms/SidePanel/ManuscriptSidePanel/Tabs/CreditTab/index.tsx
@@ -1,14 +1,10 @@
-// import ContributorsSection from "./ContributorsSsection";
-import Credits from "./Credits";
-// import OrganizationsSection from "./OrganizationsSection";
-import PropertyTagsSection from "./PropertyTagsSection";
+import Credits from "./Credits";;
 
 interface CreditTabProps {}
 
 const CreditTab = (props: CreditTabProps) => {
   return (
     <div className="flex flex-col gap-0">
-      <PropertyTagsSection />
       <Credits />
       {/* <OrganizationsSection /> */}
     </div>

--- a/src/components/organisms/SidePanel/ManuscriptSidePanel/index.tsx
+++ b/src/components/organisms/SidePanel/ManuscriptSidePanel/index.tsx
@@ -10,6 +10,7 @@ import ManuscriptAttributesSection from "@src/components/organisms/ManuscriptAtt
 import ManuscriptComponentsSection from "@components/organisms/SidePanel/ManuscriptSidePanel/Tabs/Components/ManuscriptComponentsSection";
 import {
   convertUUIDToHex,
+  filterForNonData,
   isWindows,
   lockScroll,
   restoreScroll,
@@ -106,8 +107,8 @@ const ManuscriptSidePanel = (props: ManuscriptSidePanelProps) => {
     ResearchObjectV1 | undefined
   >(manifestData);
   const [, setMounted] = useState(false);
-  const [closeCube, setCloseCube] = useLocalStorageState("closeCub", false);
-  
+  const [closeCube, setCloseCube] = useLocalStorageState("closeCube", false);
+
   const refVideo = useRef(null);
 
   useEffect(() => {
@@ -162,23 +163,10 @@ const ManuscriptSidePanel = (props: ManuscriptSidePanelProps) => {
   }, [userProfile]);
 
   const showCloseButton =
-    componentStack.filter(
-      (a) =>
-        a &&
-        a.type !== ResearchObjectComponentType.DATA &&
-        a.type !== ResearchObjectComponentType.UNKNOWN &&
-        a.type !== ResearchObjectComponentType.DATA_BUCKET
-    ).length > 0 &&
+    componentStack.filter(filterForNonData).length > 0 &&
     (!isCodeActive || selectedAnnotationId);
   const isResearchPanelReallyOpen =
-    isResearchPanelOpen ||
-    componentStack.filter(
-      (a) =>
-        a &&
-        a.type !== ResearchObjectComponentType.DATA &&
-        a.type !== ResearchObjectComponentType.UNKNOWN &&
-        a.type !== ResearchObjectComponentType.DATA_BUCKET
-    ).length < 1;
+    isResearchPanelOpen || componentStack.filter(filterForNonData).length < 1;
 
   const canShowDrive = !publicView && userProfile.userId > 0;
 

--- a/src/components/organisms/SidePanel/ManuscriptSidePanel/index.tsx
+++ b/src/components/organisms/SidePanel/ManuscriptSidePanel/index.tsx
@@ -38,6 +38,8 @@ import {
   toggleResearchPanel,
 } from "@src/state/nodes/nodeReader";
 import { SwitchBar, SwitchButton } from "@src/components/atoms/SwitchBar";
+import MetadataKeywords from "@src/components/organisms/SidePanel/ManuscriptSidePanel/Tabs/Components/MetadataKeywords";
+import useLocalStorageState from "@src/hooks/useLocalStorageState";
 
 const ManuscriptSidePanelContainer = styled(SidePanel).attrs({
   className: "bg-light-gray dark:bg-dark-gray text-black dark:text-white",
@@ -104,13 +106,9 @@ const ManuscriptSidePanel = (props: ManuscriptSidePanelProps) => {
     ResearchObjectV1 | undefined
   >(manifestData);
   const [, setMounted] = useState(false);
-  const [closeCube, setCloseCube] = useState(
-    window.localStorage.getItem("closeCube") == "1"
-  );
+  const [closeCube, setCloseCube] = useLocalStorageState("closeCub", false);
+  
   const refVideo = useRef(null);
-  useEffect(() => {
-    window.localStorage.setItem("closeCube", closeCube ? "1" : "0");
-  }, [closeCube]);
 
   useEffect(() => {
     const didPush = !!nodeVersions;
@@ -167,9 +165,9 @@ const ManuscriptSidePanel = (props: ManuscriptSidePanelProps) => {
     componentStack.filter(
       (a) =>
         a &&
-        a.type != ResearchObjectComponentType.DATA &&
-        a.type != ResearchObjectComponentType.UNKNOWN &&
-        a.type != ResearchObjectComponentType.DATA_BUCKET
+        a.type !== ResearchObjectComponentType.DATA &&
+        a.type !== ResearchObjectComponentType.UNKNOWN &&
+        a.type !== ResearchObjectComponentType.DATA_BUCKET
     ).length > 0 &&
     (!isCodeActive || selectedAnnotationId);
   const isResearchPanelReallyOpen =
@@ -177,9 +175,9 @@ const ManuscriptSidePanel = (props: ManuscriptSidePanelProps) => {
     componentStack.filter(
       (a) =>
         a &&
-        a.type != ResearchObjectComponentType.DATA &&
-        a.type != ResearchObjectComponentType.UNKNOWN &&
-        a.type != ResearchObjectComponentType.DATA_BUCKET
+        a.type !== ResearchObjectComponentType.DATA &&
+        a.type !== ResearchObjectComponentType.UNKNOWN &&
+        a.type !== ResearchObjectComponentType.DATA_BUCKET
     ).length < 1;
 
   const canShowDrive = !publicView && userProfile.userId > 0;
@@ -316,6 +314,7 @@ const ManuscriptSidePanel = (props: ManuscriptSidePanelProps) => {
                   </div>
                 )}
                 <ManuscriptComponentsSection />
+                {!publicView && <MetadataKeywords />}
               </>
             ) : null}
             {researchPanelTab === ResearchTabs.history ? <HistoryTab /> : null}

--- a/src/components/organisms/SidePanel/ManuscriptSidePanel/index.tsx
+++ b/src/components/organisms/SidePanel/ManuscriptSidePanel/index.tsx
@@ -302,7 +302,7 @@ const ManuscriptSidePanel = (props: ManuscriptSidePanelProps) => {
                   </div>
                 )}
                 <ManuscriptComponentsSection />
-                {!publicView && <MetadataKeywords />}
+                {/* {!publicView && <MetadataKeywords />} */}
               </>
             ) : null}
             {researchPanelTab === ResearchTabs.history ? <HistoryTab /> : null}


### PR DESCRIPTION
Note: **Refactored Cube animation toggle logic to ``useLocalStorageState()``**

## UI Preview
<img width="315" alt="Screenshot 2023-05-17 at 07 06 13" src="https://github.com/desci-labs/nodes-web/assets/31709531/6c70a7c1-2a91-449c-9887-02dd7c2b0223">
