### PR TITLE
fix: display code licenses in metadata modal for code components

### DIFF
--- a/src/helper/license.ts
+++ b/src/helper/license.ts
@@ -1,4 +1,12 @@
-export const PDF_LICENSE_TYPES = [
+export type License = {
+  id: number;
+  name: string;
+  shortName: string;
+  spdx: string;
+  description: string;
+};
+
+export const PDF_LICENSE_TYPES: Array<License> = [
   {
     id: 1,
     name: "CC BY",
@@ -57,7 +65,7 @@ export const PDF_LICENSE_TYPES = [
   },
 ];
 
-export const CODE_LICENSE_TYPES = [
+export const CODE_LICENSE_TYPES: Array<License> = [
   {
     id: 10,
     name: "MIT License",


### PR DESCRIPTION
# quick fix
- List code licenses in metadata modal for code components

# Preview of UI changes

<img width="701" alt="Screenshot 2023-05-30 at 13 12 13" src="https://github.com/desci-labs/nodes-web/assets/31709531/2a530a4a-9a7f-48d4-9a4b-568de77e882c">
<img width="292" alt="Screenshot 2023-05-30 at 13 12 28" src="https://github.com/desci-labs/nodes-web/assets/31709531/6d4a419d-b3e7-4c19-906b-a68f1deea155">
