### PR TITLE
Switch IPFS endpoint default from `host.docker.internal` to `localhost`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,7 @@ REACT_APP_ALCHEMY_OPTIMISM_KOVAN=
 # [default: http://localhost:5420] set to root URL of backend
 REACT_APP_NODES_API=http://localhost:5420
 # [default: http://host.docker.internal/ipfs] clear to stop overwriting manifest files URLs with default IPFS gateway.
-# Suggestion: Update hosts file to make 127.0.0.1 = host.docker.internal and set to http://host.docker.internal:8089/ipfs
-REACT_APP_IPFS_RESOLVER_OVERRIDE=http://host.docker.internal:8089/ipfs
+REACT_APP_IPFS_RESOLVER_OVERRIDE=http://localhost:8089/ipfs
 REACT_APP_PUBLIC_IPFS_RESOLVER=https://ipfs.io/ipfs
 
 # [default: undefined] set to true for debug logging


### PR DESCRIPTION
Previous configuration does not work with linux out of the box.