### PR TITLE
Fix: manifestCid availability in published nodes

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -363,7 +363,7 @@ export interface GetDatasetTreeInput {
   pub?: boolean;
   shareId?: string;
 }
-debugger;
+
 export const getDatasetTree = async (params: GetDatasetTreeInput) => {
   const url = params.pub
     ? `${SCIWEAVE_URL}/v1/data/pubTree/${params.nodeUuid}/${

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -363,7 +363,7 @@ export interface GetDatasetTreeInput {
   pub?: boolean;
   shareId?: string;
 }
-
+debugger;
 export const getDatasetTree = async (params: GetDatasetTreeInput) => {
   const url = params.pub
     ? `${SCIWEAVE_URL}/v1/data/pubTree/${params.nodeUuid}/${

--- a/src/components/organisms/ManuscriptReader/hooks/useManuscriptReader.tsx
+++ b/src/components/organisms/ManuscriptReader/hooks/useManuscriptReader.tsx
@@ -5,10 +5,7 @@ import {
   ResearchObjectComponentType,
   ResearchObjectV1Component,
 } from "@desci-labs/desci-models";
-import {
-  cleanupManifestUrl,
-  triggerTooltips,
-} from "@src/components/utils";
+import { cleanupManifestUrl, triggerTooltips } from "@src/components/utils";
 import { useNodeReader } from "@src/state/nodes/hooks";
 import {
   setCurrentPdf,
@@ -94,18 +91,20 @@ export default function useManuscriptReader(publicView: boolean = false) {
       if ("manifestUrl" in parsedManuscript)
         localStorage.setItem("manifest-url", parsedManuscript.manifestUrl);
     } else {
-      setIsError(true)
+      setIsError(true);
     }
   };
 
   const initPublicViewer = async (cid: string) => {
     if ("uuid" in parsedManuscript && !!parsedManuscript.uuid) {
-      const { uuid } = parsedManuscript;
+      const { uuid, manifestUrl } = parsedManuscript;
 
       dispatch(setCurrentPdf(""));
       setIsNew(false);
       setIsAnnotating(false);
       const currentId = uuid;
+
+      dispatch(setManifestCid(manifestUrl));
 
       if ("manifest" in parsedManuscript && !!parsedManuscript.manifest) {
         const defaultComponent = getDefaultComponentForView(
@@ -182,7 +181,7 @@ export default function useManuscriptReader(publicView: boolean = false) {
           dispatch(setComponentStack([targetComponent]));
         }
       } else {
-        setIsError(true)
+        setIsError(true);
       }
       dispatch(setCurrentObjectId(currentId));
       dispatch(setResearchPanelTab(ResearchTabs.current));
@@ -197,7 +196,7 @@ export default function useManuscriptReader(publicView: boolean = false) {
    */
   useEffect(() => {
     if ("error" in parsedManuscript) {
-      setIsError(true)
+      setIsError(true);
     }
     if (publicView) {
       const uuid = "uuid" in parsedManuscript ? parsedManuscript.uuid : "";

--- a/src/components/screens/Nodes.tsx
+++ b/src/components/screens/Nodes.tsx
@@ -3,6 +3,7 @@ import {
   RESEARCH_OBJECT_NODES_PREFIX,
 } from "@desci-labs/desci-models";
 import {
+  getPublishedVersions,
   getRecentPublishedManifest,
   getResearchObjectStub,
   resolvePrivateResearchObjectStub,
@@ -11,7 +12,7 @@ import {
 } from "@src/api";
 import axios from "axios";
 import { LoaderFunctionArgs, Outlet, Params } from "react-router-dom";
-import { cleanupManifestUrl } from "../utils";
+import { cleanupManifestUrl, convertHexToCID } from "../utils";
 import { ReaderMode } from "@src/state/nodes/nodeReader";
 
 export type ManuscriptLoaderData =
@@ -31,6 +32,7 @@ export type ManuscriptLoaderData =
       annotationIndex: string;
       manifest: ResearchObjectV1;
       params: Params<string>;
+      manifestUrl: string;
     }
   | {
       error: boolean;
@@ -99,8 +101,17 @@ export const manuscriptLoader = async ({
         ? await resolvePublishedManifest(uuid, version)
         : await getRecentPublishedManifest(uuid);
 
+      // Resolve manifest cid
+      const versions = await getPublishedVersions(uuid);
+      const reversedVersions = versions.versions.reverse();
+      const specificVersion = version
+        ? reversedVersions[version]
+        : reversedVersions[reversedVersions.length - 1];
+      const manifestCid = convertHexToCID(specificVersion.cid);
+
       return {
         uuid,
+        manifestUrl: manifestCid,
         version,
         manifest,
         componentIndex,


### PR DESCRIPTION
The new tree retrieval API expects a manifest CID instead of a root CID, however manifestCid state was omitted in published view state, added the resolution of the published node's maniefstCid so trees are retrieved correctly.