### PR TITLE
Draft tree changes, publish step adjustments

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -741,3 +741,28 @@ export const stopTracking = async () => {
     amplitude.reset();
   }
 };
+
+export type PrepublishResponse =
+  | PrepublishSuccessResponse
+  | PrepublishErrorResponse;
+export interface PrepublishSuccessResponse {
+  ok: boolean;
+  updatedManifestCid: string;
+  updatedManifest: ResearchObjectV1;
+  version?: NodeVersion;
+}
+
+export interface PrepublishErrorResponse {
+  ok: false;
+  error: string;
+  status?: number;
+}
+
+export const prepublish = async (uuid: string): Promise<PrepublishResponse> => {
+  const { data } = await axios.post(
+    `${SCIWEAVE_URL}/v1/nodes/prepublish`,
+    { uuid },
+    config()
+  );
+  return data;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -344,6 +344,7 @@ export const publishResearchObject = async (input: {
   cid: string;
   manifest: ResearchObjectV1;
   transactionId: string;
+  nodeVersionId?: number;
 }) => {
   const options: AxiosRequestConfig = config();
   options.headers["content-type"] = "application/json";

--- a/src/components/organisms/PopOver/CommitStatusPopover.tsx
+++ b/src/components/organisms/PopOver/CommitStatusPopover.tsx
@@ -144,6 +144,9 @@ const CommitStatusPopover = (props: ModalProps & { onSuccess: () => void }) => {
               base64UuidToBase16,
               cid
             );
+            modifiedObject.manifest = updatedManifest;
+            modifiedObject.cid = updatedManifestCid;
+            modifiedObject.nodeVersionId = version?.id;
           } else {
             throw new Error(
               `Prepublish failed: ${
@@ -284,7 +287,7 @@ const CommitStatusPopover = (props: ModalProps & { onSuccess: () => void }) => {
         // );
         if (currentObjectId && manifestCid && manifestData) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
+          // debugger;
           publishResearchObject({
             uuid: currentObjectId,
             cid: modifiedObject.cid,

--- a/src/components/organisms/PopOver/CommitStatusPopover.tsx
+++ b/src/components/organisms/PopOver/CommitStatusPopover.tsx
@@ -201,7 +201,7 @@ const CommitStatusPopover = (props: ModalProps & { onSuccess: () => void }) => {
           }
 
           const regFee = await dpidContract.functions.getFee();
-          const hashBytes = getBytesFromCIDString(hash);
+          const hashBytes = getBytesFromCIDString(publishManifestCid);
           tx = await contract.functions.mintWithDpid(
             base64UuidToBase16,
             hashBytes,


### PR DESCRIPTION
To be merged in with the nodes backend draft tree changes, this enables publish compatibility with the new draft trees by triggering a DAGify prepublish step.